### PR TITLE
fix(jore-graphql): change get_stations GraphQL-function SQL to not re…

### DIFF
--- a/src/createFunctions.sql
+++ b/src/createFunctions.sql
@@ -138,6 +138,7 @@ FROM (
     AND stop.terminal_id IS NOT NULL
     AND type = '01'
     AND date between route.date_begin and route.date_end
+    AND date between route_segment.date_begin and route_segment.date_end
     AND ST_Intersects(stop.point, ST_MakeEnvelope(min_lon, min_lat, max_lon, max_lat, 4326))
 ) stations
 GROUP BY terminal_id


### PR DESCRIPTION
…turn stations with routes with no route segments

get_stations -function would return "Nikkila" terminal even though no routes would go through it after certain date. Logic now checks period of validity by actual route segments going through terminal. Previous logic checked period of validity for route only. This caused situation where route continued to exist but change it course in a way that stops associated to the route would be drawn as terminal.