### PR TITLE
geometry matcher and dump processing enhancements 

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -44,8 +44,8 @@ export const ADMIN_PASSWORD = secretsEnv.ADMIN_PASSWORD || "password";
 export const PATH_PREFIX = secretsEnv.PATH_PREFIX || "/";
 export const PYTHON_CMD = process.env.PYTHON_CMD || "python";
 export const PBF_DOWNLOAD_URL =
-  "http://download.geofabrik.de/europe/finland-latest.osm.pbf";
-export const PBF_FILENAME = "finland-latest.osm.pbf";
+  "https://karttapalvelu.storage.hsldev.com/hsl.osm/hsl.osm.pbf";
+export const PBF_FILENAME = "hsl.osm.pbf";
 export const SCHEMA = "jore";
 export const INTERMEDIATE_SCHEMA = "jore_new";
 export const AZURE_UPLOAD_CONTAINER = secretsEnv.AZURE_UPLOAD_CONTAINER || "joredumps";

--- a/src/import.js
+++ b/src/import.js
@@ -128,8 +128,13 @@ export async function importFile(filePath) {
 
     // Disallow dump and upload by unsetting AZURE_STORAGE_ACCOUNT
     if (AZURE_STORAGE_ACCOUNT) {
-      const dumpFilePath = await createDbDump();
-      await uploadDbDump(dumpFilePath);
+      try {
+        const dumpFilePath = await createDbDump();
+        await uploadDbDump(dumpFilePath);
+      } catch (err) {
+        console.log(err.message || "DB upload failed.");
+        console.log(err);
+      }
     }
 
     const [execDuration] = process.hrtime(execStart);

--- a/src/utils/createDbDump.js
+++ b/src/utils/createDbDump.js
@@ -5,7 +5,6 @@ import fs from "fs-extra";
 import format from "date-fns/format";
 import { parse } from "pg-connection-string";
 
-const currentDate = format(new Date(), "YYYY-MM-DD");
 const cwd = process.cwd();
 const dumpsDir = path.join(cwd, "dumps");
 
@@ -17,6 +16,7 @@ export const createDbDump = async () => {
     let lastError = null;
 
     await fs.ensureDir(dumpsDir);
+    const currentDate = format(new Date(), "YYYY-MM-DD");
     const currentDateFilename = `jore_dump_${currentDate}`;
     const filePath = path.join(dumpsDir, currentDateFilename);
     const fileExists = await fs.pathExists(filePath);

--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -1,10 +1,10 @@
-import http from "http";
+import https from "https";
 import fs from "fs-extra";
 
 export const download = (url, dest) => {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
-    http
+    https
       .get(url, (response) => {
         response.pipe(file);
         file.on("finish", () => {


### PR DESCRIPTION
This pull request:

- Fixes bug with db dump where the creation date in the dump file did not update with current date
- Better error handling for dump upload process
- OpenStreetMap PBF-data for geometry matcher is now fetched over HTTPS *and* from HSL hosted mirror *and* is of more concise size (covers HSL area) 
- Geometry matcher now gets fresh OSM-data during import run (the OSM data is updated daily) if the current file in use is over 24 hours old
