### PR TITLE
Bump debian version to fix dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-buster-slim
+FROM node:18-bookworm-slim
 
 ENV IMPORTER_DIR /opt/jore
 ENV NODE_ENV production


### PR DESCRIPTION
`18-buster-slim` was encountering dependency issues when downloading from http://apt.postgresql.org/pub/repos/apt/dists/ to buster not being present anymore. Bumped the debian version to `bookworm`